### PR TITLE
Add support for specific hidden folders in search

### DIFF
--- a/find_large/constants.py
+++ b/find_large/constants.py
@@ -14,6 +14,9 @@ MB_TO_BYTES: Final[int] = KB_TO_BYTES * 1024
 GB_TO_BYTES: Final[int] = MB_TO_BYTES * 1024
 TB_TO_BYTES: Final[int] = GB_TO_BYTES * 1024
 
+# Hidden folders to include in search
+INCLUDE_HIDDEN_FOLDERS: Final[set[str]] = {'.git', '.config', '.huggingface', '.local'}
+
 # System folders to exclude from search
 EXCLUDE_FOLDERS: Final[List[str]] = [
     # System directories

--- a/find_large/core.py
+++ b/find_large/core.py
@@ -17,6 +17,7 @@ from .constants import (
     GB_TO_BYTES,
     TB_TO_BYTES,
     EXCLUDE_FOLDERS,
+    INCLUDE_HIDDEN_FOLDERS,
     SIZE_UNIT_GB,
     SIZE_UNIT_MB,
     SIZE_UNIT_TB,
@@ -65,7 +66,8 @@ class SizeScannerBase:
 
     def should_skip_path(self, path: str) -> bool:
         """Check if a path should be skipped."""
-        if os.path.basename(path).startswith('.'):
+        basename = os.path.basename(path)
+        if basename.startswith('.') and basename not in INCLUDE_HIDDEN_FOLDERS:
             return True
         
         abs_path = os.path.abspath(path)


### PR DESCRIPTION
# feat ✨: Add support for specific hidden folders in search

This PR adds functionality to include specific hidden folders in the search results while maintaining the general behavior of skipping hidden folders.

Changes:
- Added `INCLUDE_HIDDEN_FOLDERS` constant with initial set of important hidden folders (.git, .config, .huggingface, .local)
- Modified `should_skip_path` in `SizeScannerBase` to check if hidden folders are in the include list before skipping

This change allows users to find large files in commonly used hidden folders that often contain significant data, while still maintaining the default behavior of skipping most hidden folders.

Testing:
- [ ] Verify that specified hidden folders are included in search results
- [ ] Confirm other hidden folders are still skipped
- [ ] Check that regular folder scanning behavior remains unchanged

No breaking changes.