### PR TITLE
chore 📦: Bump version metadata and fix Renovate config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,5 +19,4 @@ jobs:
       - name: Renovate Bot GitHub Action
         uses: renovatebot/github-action@v44.2.5
         with:
-          configurationFile: renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A command-line tool to search for and list large files in a directory. This util
 
 ## Badges
 
-![Python](https://img.shields.io/badge/python-3.6%2B-blue)
+![Python](https://img.shields.io/badge/python-3.12%2B-blue)
 ![Version](https://img.shields.io/badge/version-0.2.1-green)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command-line tool to search for and list large files in a directory. This util
 
 ## Versions
 
-**Current version**: 0.2.0 - Current release with support for finding large files, directories, and video files.
+**Current version**: 0.2.1 - Maintenance release with expanded test coverage.
 
 ## Table of Contents
 
@@ -18,7 +18,7 @@ A command-line tool to search for and list large files in a directory. This util
 ## Badges
 
 ![Python](https://img.shields.io/badge/python-3.6%2B-blue)
-![Version](https://img.shields.io/badge/version-0.2.0-green)
+![Version](https://img.shields.io/badge/version-0.2.1-green)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ## Installation

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,10 +2,38 @@
 
 ## ToC
 
-- [v0.2.0](#v020-current---18-01-2026)
+- [v0.2.1](#v021-current---21-01-2026)
+- [v0.2.0](#v020---18-01-2026)
 - [v0.1.0](#v010---01-01-2026)
 
-## **v0.2.0** (Current) - *18-01-2026*
+## **v0.2.1** (Current) - *21-01-2026*
+
+### 🐛 **Bug Fix Release**
+
+### 🧪 **Testing Improvements in v0.2.1**
+
+- **Added**: Expanded end-to-end and unit test coverage for CLI workflows.
+- **Enhanced**: Added fixtures and return type checks to ensure consistent outputs.
+
+### 🐛 **Bug Fixes in v0.2.1**
+
+- **Fixed**: Updated video scanner to use consistent MB-to-bytes conversion.
+  - **Issue**: Video thresholds were computed with mismatched constants.
+  - **Root Cause**: The scanner used a legacy conversion value.
+  - **Solution**: Standardized on the MB_TO_BYTES constant.
+
+### 🔧 **Improvements in v0.2.1**
+
+- **Improved**: Added MB_TO_BYTES constant to the formatting utilities.
+- **Updated**: Maintenance updates for CodeQL schedule and workflow configuration.
+
+### 📝 **Key Commits in v0.2.1**
+
+`5af2038`, `54db851`, `d4e584c`, `9187b21`, `163e90f`
+
+______________________________________________________________________
+
+## **v0.2.0** - *18-01-2026*
 
 ### ✨ **Feature Release**
 

--- a/find_large/__init__.py
+++ b/find_large/__init__.py
@@ -6,7 +6,7 @@ in a given directory, with options for different output formats and filtering.
 
 from find_large.cli import main as main
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "elvee"
 __description__ = (
     "A command-line utility to help you identify space-consuming files and directories"

--- a/project-overview.md
+++ b/project-overview.md
@@ -1,16 +1,17 @@
 # Project Overview
 
-[![Version](https://img.shields.io/badge/Version-v0.2.0-informational)](./VERSIONS.md)
+[![Version](https://img.shields.io/badge/Version-v0.2.1-informational)](./VERSIONS.md)
 
 ## Current Version
 
-- **Version**: v0.2.0
-- **Release Date**: 18-01-2026
-- **Summary**: Feature release focused on the PDM/pyproject migration and scanner refactors.
+- **Version**: v0.2.1
+- **Release Date**: 21-01-2026
+- **Summary**: Maintenance release focused on comprehensive test coverage.
 
 ## Release Overview
 
 | Version | Date | Summary |
 | -- | -- | -- |
+| v0.2.1 | 21-01-2026 | Expanded test coverage with new fixtures and validations. |
 | v0.2.0 | 18-01-2026 | PDM migration, refactors, and documentation updates. |
 | v0.1.0 | 01-01-2026 | Initial release. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "find-large"
-version = "0.2.0"
+version = "0.2.1"
 description = "A tool to search for large files in a system"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Pull Request: Bump version metadata and fix Renovate config

## Summary

This PR bumps project metadata to v0.2.1 and refreshes release documentation while adjusting the Renovate workflow to rely on config auto-discovery. Net effect: version references align across docs and package metadata, and the scheduled Renovate job no longer fails on a missing config path.

## Why

- Keep version and release notes consistent across README, VERSIONS, and project metadata.
- Align the project overview with the current release.
- Resolve Renovate schedule failures caused by a hard-coded configuration file path.

## Notable changes (reviewer focus)

- Removed the explicit `configurationFile` option so Renovate uses default config discovery.
- Updated version references and badges to v0.2.1.
- Added v0.2.1 release notes and adjusted the ToC in VERSIONS.md.

## Files changed

- **Counts:** 6 files changed (A 0, M 6, D 0).
- **Key touchpoints:** Renovate workflow config, version metadata, release notes, README and project overview badges.

<details>
<summary>File lists (auto)</summary>

### Added
- None

### Modified
- `.github/workflows/renovate.yml`
- `README.md`
- `VERSIONS.md`
- `find_large/__init__.py`
- `project-overview.md`
- `pyproject.toml`

### Deleted
- None

</details>

## Test plan

- [ ] Unit: N/A (docs/config changes only).
- [ ] Integration: N/A.
- [ ] Manual: N/A.

## Risks & rollback

- **Risks:** Low; Renovate now relies on default config discovery. If repo layout changes, discovery could fail.
- **Rollback:** Revert this PR or reintroduce `configurationFile` with a verified path.

## Additional notes

- Intended merge: `dev` → `main`.
